### PR TITLE
Benchmark Ascon, Keccak-p[400] Permutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ make benchmark
 ### On AWS Graviton3
 
 ```fish
-2022-06-20T17:32:05+00:00
+2022-06-24T09:03:25+00:00
 Running ./bench/a.out
 Run on (64 X 2100 MHz CPU s)
 CPU Caches:
@@ -101,88 +101,160 @@ CPU Caches:
   L1 Instruction 64 KiB (x64)
   L2 Unified 1024 KiB (x64)
   L3 Unified 32768 KiB (x1)
-Load Average: 0.10, 0.03, 0.01
+Load Average: 0.24, 0.06, 0.02
 -------------------------------------------------------------------------------------------------------
 Benchmark                                             Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------------------------
-isap_bench::isap_a_128a_aead_encrypt/32/64         2498 ns         2498 ns       280075 bytes_per_second=36.644M/s
-isap_bench::isap_a_128a_aead_decrypt/32/64         2512 ns         2512 ns       278677 bytes_per_second=36.4508M/s
-isap_bench::isap_a_128a_aead_encrypt/32/128        3138 ns         3138 ns       223048 bytes_per_second=48.6265M/s
-isap_bench::isap_a_128a_aead_decrypt/32/128        3151 ns         3151 ns       222185 bytes_per_second=48.4209M/s
-isap_bench::isap_a_128a_aead_encrypt/32/256        4413 ns         4413 ns       158607 bytes_per_second=62.2367M/s
-isap_bench::isap_a_128a_aead_decrypt/32/256        4429 ns         4429 ns       158001 bytes_per_second=62.0193M/s
-isap_bench::isap_a_128a_aead_encrypt/32/512        6987 ns         6987 ns        99901 bytes_per_second=74.2497M/s
-isap_bench::isap_a_128a_aead_decrypt/32/512        7005 ns         7004 ns        99998 bytes_per_second=74.0678M/s
-isap_bench::isap_a_128a_aead_encrypt/32/1024      12128 ns        12127 ns        57748 bytes_per_second=83.0416M/s
-isap_bench::isap_a_128a_aead_decrypt/32/1024      12146 ns        12146 ns        57633 bytes_per_second=82.914M/s
-isap_bench::isap_a_128a_aead_encrypt/32/2048      22469 ns        22468 ns        31155 bytes_per_second=88.286M/s
-isap_bench::isap_a_128a_aead_decrypt/32/2048      22448 ns        22447 ns        31183 bytes_per_second=88.3707M/s
-isap_bench::isap_a_128a_aead_encrypt/32/4096      42972 ns        42971 ns        16284 bytes_per_second=91.6151M/s
-isap_bench::isap_a_128a_aead_decrypt/32/4096      43020 ns        43018 ns        16283 bytes_per_second=91.5134M/s
-isap_bench::isap_a_128_aead_encrypt/32/64         14868 ns        14868 ns        47067 bytes_per_second=6.15769M/s
-isap_bench::isap_a_128_aead_decrypt/32/64         14867 ns        14867 ns        47079 bytes_per_second=6.15818M/s
-isap_bench::isap_a_128_aead_encrypt/32/128        15702 ns        15702 ns        44572 bytes_per_second=9.71776M/s
-isap_bench::isap_a_128_aead_decrypt/32/128        15710 ns        15709 ns        44563 bytes_per_second=9.71322M/s
-isap_bench::isap_a_128_aead_encrypt/32/256        17371 ns        17371 ns        40290 bytes_per_second=15.8117M/s
-isap_bench::isap_a_128_aead_decrypt/32/256        17397 ns        17397 ns        40262 bytes_per_second=15.7878M/s
-isap_bench::isap_a_128_aead_encrypt/32/512        20780 ns        20780 ns        33685 bytes_per_second=24.9665M/s
-isap_bench::isap_a_128_aead_decrypt/32/512        20786 ns        20786 ns        33675 bytes_per_second=24.959M/s
-isap_bench::isap_a_128_aead_encrypt/32/1024       27557 ns        27556 ns        25400 bytes_per_second=36.5465M/s
-isap_bench::isap_a_128_aead_decrypt/32/1024       27560 ns        27559 ns        25403 bytes_per_second=36.5424M/s
-isap_bench::isap_a_128_aead_encrypt/32/2048       41475 ns        41474 ns        16875 bytes_per_second=47.8282M/s
-isap_bench::isap_a_128_aead_decrypt/32/2048       41127 ns        41127 ns        17010 bytes_per_second=48.2326M/s
-isap_bench::isap_a_128_aead_encrypt/32/4096       68807 ns        68806 ns        10174 bytes_per_second=57.2153M/s
-isap_bench::isap_a_128_aead_decrypt/32/4096       68595 ns        68595 ns        10205 bytes_per_second=57.3918M/s
+isap_bench::ascon_permutation<1>                   6.83 ns         6.83 ns    102346075 bytes_per_second=5.45043G/s
+isap_bench::ascon_permutation<6>                   28.4 ns         28.4 ns     24625129 bytes_per_second=1.31138G/s
+isap_bench::ascon_permutation<12>                  54.7 ns         54.7 ns     12783053 bytes_per_second=697.62M/s
+isap_bench::keccak_permutation<1>                  40.4 ns         40.4 ns     17369151 bytes_per_second=1.15346G/s
+isap_bench::keccak_permutation<8>                   240 ns          240 ns      2917582 bytes_per_second=198.742M/s
+isap_bench::keccak_permutation<12>                  338 ns          338 ns      2070655 bytes_per_second=141.113M/s
+isap_bench::keccak_permutation<16>                  449 ns          449 ns      1560318 bytes_per_second=106.279M/s
+isap_bench::keccak_permutation<20>                  562 ns          562 ns      1246480 bytes_per_second=84.8449M/s
+isap_bench::isap_a_128a_aead_encrypt/32/64         2536 ns         2536 ns       276146 bytes_per_second=36.1049M/s
+isap_bench::isap_a_128a_aead_decrypt/32/64         2549 ns         2549 ns       274763 bytes_per_second=35.9227M/s
+isap_bench::isap_a_128a_aead_encrypt/32/128        3191 ns         3191 ns       219363 bytes_per_second=47.8193M/s
+isap_bench::isap_a_128a_aead_decrypt/32/128        3205 ns         3205 ns       218528 bytes_per_second=47.6131M/s
+isap_bench::isap_a_128a_aead_encrypt/32/256        4497 ns         4497 ns       155462 bytes_per_second=61.0804M/s
+isap_bench::isap_a_128a_aead_decrypt/32/256        4505 ns         4505 ns       155173 bytes_per_second=60.9739M/s
+isap_bench::isap_a_128a_aead_encrypt/32/512        7092 ns         7092 ns        98687 bytes_per_second=73.1503M/s
+isap_bench::isap_a_128a_aead_decrypt/32/512        7112 ns         7111 ns        98532 bytes_per_second=72.9521M/s
+isap_bench::isap_a_128a_aead_encrypt/32/1024      12374 ns        12374 ns        56570 bytes_per_second=81.3863M/s
+isap_bench::isap_a_128a_aead_decrypt/32/1024      12386 ns        12386 ns        56515 bytes_per_second=81.3069M/s
+isap_bench::isap_a_128a_aead_encrypt/32/2048      22870 ns        22870 ns        30605 bytes_per_second=86.7358M/s
+isap_bench::isap_a_128a_aead_decrypt/32/2048      22866 ns        22866 ns        30594 bytes_per_second=86.7523M/s
+isap_bench::isap_a_128a_aead_encrypt/32/4096      43866 ns        43864 ns        15971 bytes_per_second=89.7497M/s
+isap_bench::isap_a_128a_aead_decrypt/32/4096      43878 ns        43877 ns        15954 bytes_per_second=89.723M/s
+isap_bench::isap_a_128_aead_encrypt/32/64         14926 ns        14926 ns        46895 bytes_per_second=6.13389M/s
+isap_bench::isap_a_128_aead_decrypt/32/64         14941 ns        14941 ns        46856 bytes_per_second=6.12769M/s
+isap_bench::isap_a_128_aead_encrypt/32/128        15767 ns        15767 ns        44426 bytes_per_second=9.67775M/s
+isap_bench::isap_a_128_aead_decrypt/32/128        15791 ns        15791 ns        44316 bytes_per_second=9.66307M/s
+isap_bench::isap_a_128_aead_encrypt/32/256        17467 ns        17466 ns        40078 bytes_per_second=15.7256M/s
+isap_bench::isap_a_128_aead_decrypt/32/256        17486 ns        17485 ns        40035 bytes_per_second=15.7079M/s
+isap_bench::isap_a_128_aead_encrypt/32/512        20848 ns        20847 ns        33575 bytes_per_second=24.8855M/s
+isap_bench::isap_a_128_aead_decrypt/32/512        20864 ns        20863 ns        33550 bytes_per_second=24.8667M/s
+isap_bench::isap_a_128_aead_encrypt/32/1024       27604 ns        27603 ns        25360 bytes_per_second=36.4839M/s
+isap_bench::isap_a_128_aead_decrypt/32/1024       27620 ns        27618 ns        25349 bytes_per_second=36.4642M/s
+isap_bench::isap_a_128_aead_encrypt/32/2048       41104 ns        41102 ns        17053 bytes_per_second=48.261M/s
+isap_bench::isap_a_128_aead_decrypt/32/2048       41108 ns        41107 ns        17027 bytes_per_second=48.2555M/s
+isap_bench::isap_a_128_aead_encrypt/32/4096       68096 ns        68092 ns        10279 bytes_per_second=57.8153M/s
+isap_bench::isap_a_128_aead_decrypt/32/4096       68111 ns        68110 ns        10279 bytes_per_second=57.8004M/s
+isap_bench::isap_k_128a_aead_encrypt/32/64        13309 ns        13308 ns        52602 bytes_per_second=6.87945M/s
+isap_bench::isap_k_128a_aead_decrypt/32/64        13320 ns        13319 ns        52562 bytes_per_second=6.87378M/s
+isap_bench::isap_k_128a_aead_encrypt/32/128       16131 ns        16131 ns        43388 bytes_per_second=9.45923M/s
+isap_bench::isap_k_128a_aead_decrypt/32/128       16142 ns        16141 ns        43365 bytes_per_second=9.45345M/s
+isap_bench::isap_k_128a_aead_encrypt/32/256       21092 ns        21091 ns        33190 bytes_per_second=13.0222M/s
+isap_bench::isap_k_128a_aead_decrypt/32/256       21103 ns        21102 ns        33173 bytes_per_second=13.0158M/s
+isap_bench::isap_k_128a_aead_encrypt/32/512       31017 ns        31016 ns        22569 bytes_per_second=16.7268M/s
+isap_bench::isap_k_128a_aead_decrypt/32/512       31030 ns        31029 ns        22560 bytes_per_second=16.7197M/s
+isap_bench::isap_k_128a_aead_encrypt/32/1024      50851 ns        50850 ns        13766 bytes_per_second=19.8049M/s
+isap_bench::isap_k_128a_aead_decrypt/32/1024      50860 ns        50859 ns        13764 bytes_per_second=19.8015M/s
+isap_bench::isap_k_128a_aead_encrypt/32/2048      91214 ns        91212 ns         7673 bytes_per_second=21.7477M/s
+isap_bench::isap_k_128a_aead_decrypt/32/2048      91210 ns        91207 ns         7674 bytes_per_second=21.7487M/s
+isap_bench::isap_k_128a_aead_encrypt/32/4096     171933 ns       171928 ns         4071 bytes_per_second=22.8977M/s
+isap_bench::isap_k_128a_aead_decrypt/32/4096     171933 ns       171929 ns         4071 bytes_per_second=22.8976M/s
+isap_bench::isap_k_128_aead_encrypt/32/64         94713 ns        94710 ns         7391 bytes_per_second=989.867k/s
+isap_bench::isap_k_128_aead_decrypt/32/64         94643 ns        94641 ns         7398 bytes_per_second=990.588k/s
+isap_bench::isap_k_128_aead_encrypt/32/128        98504 ns        98502 ns         7105 bytes_per_second=1.54909M/s
+isap_bench::isap_k_128_aead_decrypt/32/128        98405 ns        98402 ns         7112 bytes_per_second=1.55066M/s
+isap_bench::isap_k_128_aead_encrypt/32/256       105193 ns       105189 ns         6658 bytes_per_second=2.6111M/s
+isap_bench::isap_k_128_aead_decrypt/32/256       105109 ns       105105 ns         6658 bytes_per_second=2.61317M/s
+isap_bench::isap_k_128_aead_encrypt/32/512       118654 ns       118652 ns         5903 bytes_per_second=4.37245M/s
+isap_bench::isap_k_128_aead_decrypt/32/512       118539 ns       118537 ns         5906 bytes_per_second=4.37669M/s
+isap_bench::isap_k_128_aead_encrypt/32/1024      145345 ns       145341 ns         4814 bytes_per_second=6.92907M/s
+isap_bench::isap_k_128_aead_decrypt/32/1024      145271 ns       145268 ns         4819 bytes_per_second=6.93256M/s
+isap_bench::isap_k_128_aead_encrypt/32/2048      199711 ns       199706 ns         3504 bytes_per_second=9.93283M/s
+isap_bench::isap_k_128_aead_decrypt/32/2048      199729 ns       199725 ns         3505 bytes_per_second=9.93186M/s
+isap_bench::isap_k_128_aead_encrypt/32/4096      308668 ns       308659 ns         2267 bytes_per_second=12.7544M/s
+isap_bench::isap_k_128_aead_decrypt/32/4096      308678 ns       308672 ns         2268 bytes_per_second=12.7539M/s
 ```
 
 ### On AWS Graviton2
 
 ```fish
-2022-06-20T17:33:59+00:00
+2022-06-24T09:00:25+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.36, 0.10, 0.04
+Load Average: 0.49, 0.17, 0.06
 -------------------------------------------------------------------------------------------------------
 Benchmark                                             Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------------------------
-isap_bench::isap_a_128a_aead_encrypt/32/64         4485 ns         4485 ns       156132 bytes_per_second=20.4115M/s
-isap_bench::isap_a_128a_aead_decrypt/32/64         4497 ns         4497 ns       155729 bytes_per_second=20.3607M/s
-isap_bench::isap_a_128a_aead_encrypt/32/128        5596 ns         5596 ns       125147 bytes_per_second=27.269M/s
-isap_bench::isap_a_128a_aead_decrypt/32/128        5606 ns         5606 ns       124876 bytes_per_second=27.2204M/s
-isap_bench::isap_a_128a_aead_encrypt/32/256        7821 ns         7821 ns        89416 bytes_per_second=35.1184M/s
-isap_bench::isap_a_128a_aead_decrypt/32/256        7838 ns         7837 ns        89267 bytes_per_second=35.0454M/s
-isap_bench::isap_a_128a_aead_encrypt/32/512       12263 ns        12263 ns        57054 bytes_per_second=42.3077M/s
-isap_bench::isap_a_128a_aead_decrypt/32/512       12275 ns        12275 ns        57025 bytes_per_second=42.2651M/s
-isap_bench::isap_a_128a_aead_encrypt/32/1024      21146 ns        21145 ns        33096 bytes_per_second=47.6262M/s
-isap_bench::isap_a_128a_aead_decrypt/32/1024      21164 ns        21164 ns        33085 bytes_per_second=47.5855M/s
-isap_bench::isap_a_128a_aead_encrypt/32/2048      38920 ns        38919 ns        17986 bytes_per_second=50.9684M/s
-isap_bench::isap_a_128a_aead_decrypt/32/2048      38925 ns        38924 ns        17984 bytes_per_second=50.9619M/s
-isap_bench::isap_a_128a_aead_encrypt/32/4096      74457 ns        74452 ns         9402 bytes_per_second=52.8764M/s
-isap_bench::isap_a_128a_aead_decrypt/32/4096      74467 ns        74466 ns         9399 bytes_per_second=52.8664M/s
-isap_bench::isap_a_128_aead_encrypt/32/64         25957 ns        25957 ns        26969 bytes_per_second=3.52712M/s
-isap_bench::isap_a_128_aead_decrypt/32/64         25974 ns        25974 ns        26950 bytes_per_second=3.52483M/s
-isap_bench::isap_a_128_aead_encrypt/32/128        27448 ns        27448 ns        25494 bytes_per_second=5.55914M/s
-isap_bench::isap_a_128_aead_decrypt/32/128        27461 ns        27461 ns        25490 bytes_per_second=5.55659M/s
-isap_bench::isap_a_128_aead_encrypt/32/256        30455 ns        30455 ns        22986 bytes_per_second=9.01862M/s
-isap_bench::isap_a_128_aead_decrypt/32/256        30476 ns        30476 ns        22974 bytes_per_second=9.01231M/s
-isap_bench::isap_a_128_aead_encrypt/32/512        36478 ns        36477 ns        19190 bytes_per_second=14.2226M/s
-isap_bench::isap_a_128_aead_decrypt/32/512        36483 ns        36483 ns        19186 bytes_per_second=14.2203M/s
-isap_bench::isap_a_128_aead_encrypt/32/1024       48498 ns        48498 ns        14434 bytes_per_second=20.7655M/s
-isap_bench::isap_a_128_aead_decrypt/32/1024       48515 ns        48515 ns        14429 bytes_per_second=20.7583M/s
-isap_bench::isap_a_128_aead_encrypt/32/2048       72564 ns        72562 ns         9646 bytes_per_second=27.3374M/s
-isap_bench::isap_a_128_aead_decrypt/32/2048       72574 ns        72573 ns         9645 bytes_per_second=27.333M/s
-isap_bench::isap_a_128_aead_encrypt/32/4096      120686 ns       120682 ns         5800 bytes_per_second=32.621M/s
-isap_bench::isap_a_128_aead_decrypt/32/4096      120695 ns       120694 ns         5800 bytes_per_second=32.6178M/s
+isap_bench::ascon_permutation<1>                   11.7 ns         11.7 ns     59560299 bytes_per_second=3.17139G/s
+isap_bench::ascon_permutation<6>                   44.6 ns         44.6 ns     15697145 bytes_per_second=855.424M/s
+isap_bench::ascon_permutation<12>                  94.0 ns         94.0 ns      7448751 bytes_per_second=405.936M/s
+isap_bench::keccak_permutation<1>                  62.2 ns         62.2 ns     11249382 bytes_per_second=766.389M/s
+isap_bench::keccak_permutation<8>                   515 ns          515 ns      1358867 bytes_per_second=92.5696M/s
+isap_bench::keccak_permutation<12>                  770 ns          770 ns       909494 bytes_per_second=61.9564M/s
+isap_bench::keccak_permutation<16>                 1020 ns         1020 ns       686089 bytes_per_second=46.7369M/s
+isap_bench::keccak_permutation<20>                 1237 ns         1237 ns       565919 bytes_per_second=38.5512M/s
+isap_bench::isap_a_128a_aead_encrypt/32/64         4513 ns         4513 ns       155111 bytes_per_second=20.2879M/s
+isap_bench::isap_a_128a_aead_decrypt/32/64         4525 ns         4525 ns       154668 bytes_per_second=20.2324M/s
+isap_bench::isap_a_128a_aead_encrypt/32/128        5623 ns         5623 ns       124553 bytes_per_second=27.1345M/s
+isap_bench::isap_a_128a_aead_decrypt/32/128        5634 ns         5634 ns       124235 bytes_per_second=27.0832M/s
+isap_bench::isap_a_128a_aead_encrypt/32/256        7848 ns         7848 ns        89176 bytes_per_second=34.9977M/s
+isap_bench::isap_a_128a_aead_decrypt/32/256        7868 ns         7868 ns        88983 bytes_per_second=34.9085M/s
+isap_bench::isap_a_128a_aead_encrypt/32/512       12291 ns        12291 ns        56931 bytes_per_second=42.2109M/s
+isap_bench::isap_a_128a_aead_decrypt/32/512       12306 ns        12305 ns        56854 bytes_per_second=42.16M/s
+isap_bench::isap_a_128a_aead_encrypt/32/1024      21174 ns        21174 ns        33063 bytes_per_second=47.5629M/s
+isap_bench::isap_a_128a_aead_decrypt/32/1024      21191 ns        21191 ns        33038 bytes_per_second=47.524M/s
+isap_bench::isap_a_128a_aead_encrypt/32/2048      38942 ns        38941 ns        17977 bytes_per_second=50.9391M/s
+isap_bench::isap_a_128a_aead_decrypt/32/2048      38954 ns        38953 ns        17970 bytes_per_second=50.9235M/s
+isap_bench::isap_a_128a_aead_encrypt/32/4096      74481 ns        74479 ns         9399 bytes_per_second=52.8577M/s
+isap_bench::isap_a_128a_aead_decrypt/32/4096      74489 ns        74488 ns         9395 bytes_per_second=52.8509M/s
+isap_bench::isap_a_128_aead_encrypt/32/64         26013 ns        26013 ns        26909 bytes_per_second=3.51955M/s
+isap_bench::isap_a_128_aead_decrypt/32/64         26011 ns        26010 ns        26909 bytes_per_second=3.51993M/s
+isap_bench::isap_a_128_aead_encrypt/32/128        27483 ns        27483 ns        25469 bytes_per_second=5.55203M/s
+isap_bench::isap_a_128_aead_decrypt/32/128        27491 ns        27490 ns        25463 bytes_per_second=5.55059M/s
+isap_bench::isap_a_128_aead_encrypt/32/256        30454 ns        30454 ns        22989 bytes_per_second=9.01877M/s
+isap_bench::isap_a_128_aead_decrypt/32/256        30464 ns        30464 ns        22978 bytes_per_second=9.01594M/s
+isap_bench::isap_a_128_aead_encrypt/32/512        36381 ns        36381 ns        19241 bytes_per_second=14.2601M/s
+isap_bench::isap_a_128_aead_decrypt/32/512        36395 ns        36394 ns        19233 bytes_per_second=14.2551M/s
+isap_bench::isap_a_128_aead_encrypt/32/1024       48246 ns        48244 ns        14509 bytes_per_second=20.8747M/s
+isap_bench::isap_a_128_aead_decrypt/32/1024       48259 ns        48258 ns        14504 bytes_per_second=20.8687M/s
+isap_bench::isap_a_128_aead_encrypt/32/2048       71971 ns        71970 ns         9726 bytes_per_second=27.5621M/s
+isap_bench::isap_a_128_aead_decrypt/32/2048       71979 ns        71977 ns         9725 bytes_per_second=27.5595M/s
+isap_bench::isap_a_128_aead_encrypt/32/4096      119417 ns       119416 ns         5862 bytes_per_second=32.9667M/s
+isap_bench::isap_a_128_aead_decrypt/32/4096      119423 ns       119423 ns         5861 bytes_per_second=32.965M/s
+isap_bench::isap_k_128a_aead_encrypt/32/64        26548 ns        26548 ns        26363 bytes_per_second=3.44856M/s
+isap_bench::isap_k_128a_aead_decrypt/32/64        26562 ns        26562 ns        26357 bytes_per_second=3.44676M/s
+isap_bench::isap_k_128a_aead_encrypt/32/128       32360 ns        32360 ns        21631 bytes_per_second=4.71534M/s
+isap_bench::isap_k_128a_aead_decrypt/32/128       32376 ns        32375 ns        21621 bytes_per_second=4.71315M/s
+isap_bench::isap_k_128a_aead_encrypt/32/256       42548 ns        42547 ns        16452 bytes_per_second=6.45546M/s
+isap_bench::isap_k_128a_aead_decrypt/32/256       42562 ns        42561 ns        16448 bytes_per_second=6.45333M/s
+isap_bench::isap_k_128a_aead_encrypt/32/512       62918 ns        62918 ns        11124 bytes_per_second=8.24567M/s
+isap_bench::isap_k_128a_aead_decrypt/32/512       62934 ns        62933 ns        11122 bytes_per_second=8.2437M/s
+isap_bench::isap_k_128a_aead_encrypt/32/1024     103667 ns       103665 ns         6752 bytes_per_second=9.71475M/s
+isap_bench::isap_k_128a_aead_decrypt/32/1024     103680 ns       103678 ns         6751 bytes_per_second=9.71349M/s
+isap_bench::isap_k_128a_aead_encrypt/32/2048     186587 ns       186584 ns         3752 bytes_per_second=10.6314M/s
+isap_bench::isap_k_128a_aead_decrypt/32/2048     186606 ns       186603 ns         3751 bytes_per_second=10.6303M/s
+isap_bench::isap_k_128a_aead_encrypt/32/4096     352445 ns       352436 ns         1986 bytes_per_second=11.1701M/s
+isap_bench::isap_k_128a_aead_decrypt/32/4096     352460 ns       352449 ns         1986 bytes_per_second=11.1698M/s
+isap_bench::isap_k_128_aead_encrypt/32/64        191516 ns       191510 ns         3655 bytes_per_second=489.53k/s
+isap_bench::isap_k_128_aead_decrypt/32/64        191538 ns       191528 ns         3655 bytes_per_second=489.484k/s
+isap_bench::isap_k_128_aead_encrypt/32/128       199117 ns       199112 ns         3516 bytes_per_second=784.735k/s
+isap_bench::isap_k_128_aead_decrypt/32/128       199123 ns       199122 ns         3515 bytes_per_second=784.696k/s
+isap_bench::isap_k_128_aead_encrypt/32/256       212417 ns       212416 ns         3295 bytes_per_second=1.29302M/s
+isap_bench::isap_k_128_aead_decrypt/32/256       212436 ns       212435 ns         3295 bytes_per_second=1.2929M/s
+isap_bench::isap_k_128_aead_encrypt/32/512       239059 ns       239050 ns         2928 bytes_per_second=2.17025M/s
+isap_bench::isap_k_128_aead_decrypt/32/512       239068 ns       239066 ns         2928 bytes_per_second=2.1701M/s
+isap_bench::isap_k_128_aead_encrypt/32/1024      292317 ns       292315 ns         2395 bytes_per_second=3.44519M/s
+isap_bench::isap_k_128_aead_decrypt/32/1024      292345 ns       292335 ns         2395 bytes_per_second=3.44495M/s
+isap_bench::isap_k_128_aead_encrypt/32/2048      400720 ns       400715 ns         1747 bytes_per_second=4.95026M/s
+isap_bench::isap_k_128_aead_decrypt/32/2048      400755 ns       400735 ns         1747 bytes_per_second=4.95002M/s
+isap_bench::isap_k_128_aead_encrypt/32/4096      617510 ns       617507 ns         1133 bytes_per_second=6.37526M/s
+isap_bench::isap_k_128_aead_decrypt/32/4096      617511 ns       617507 ns         1134 bytes_per_second=6.37526M/s
 ```
 
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
 
 ```fish
-2022-06-21T07:56:43+04:00
+2022-06-24T13:05:27+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -190,38 +262,74 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 1.78, 1.93, 1.99
+Load Average: 1.91, 2.07, 2.15
 -------------------------------------------------------------------------------------------------------
 Benchmark                                             Time             CPU   Iterations UserCounters...
 -------------------------------------------------------------------------------------------------------
-isap_bench::isap_a_128a_aead_encrypt/32/64         2517 ns         2485 ns       278107 bytes_per_second=36.8464M/s
-isap_bench::isap_a_128a_aead_decrypt/32/64         2553 ns         2515 ns       277670 bytes_per_second=36.4089M/s
-isap_bench::isap_a_128a_aead_encrypt/32/128        3186 ns         3154 ns       210416 bytes_per_second=48.3736M/s
-isap_bench::isap_a_128a_aead_decrypt/32/128        3094 ns         3072 ns       227454 bytes_per_second=49.6644M/s
-isap_bench::isap_a_128a_aead_encrypt/32/256        4425 ns         4394 ns       164809 bytes_per_second=62.501M/s
-isap_bench::isap_a_128a_aead_decrypt/32/256        4286 ns         4259 ns       164161 bytes_per_second=64.4903M/s
-isap_bench::isap_a_128a_aead_encrypt/32/512        6695 ns         6657 ns       104984 bytes_per_second=77.9294M/s
-isap_bench::isap_a_128a_aead_decrypt/32/512        6786 ns         6737 ns       101483 bytes_per_second=77.0046M/s
-isap_bench::isap_a_128a_aead_encrypt/32/1024      11318 ns        11300 ns        62915 bytes_per_second=89.1219M/s
-isap_bench::isap_a_128a_aead_decrypt/32/1024      11951 ns        11849 ns        58641 bytes_per_second=84.9915M/s
-isap_bench::isap_a_128a_aead_encrypt/32/2048      22181 ns        21984 ns        31531 bytes_per_second=90.2292M/s
-isap_bench::isap_a_128a_aead_decrypt/32/2048      22978 ns        22582 ns        32944 bytes_per_second=87.8429M/s
-isap_bench::isap_a_128a_aead_encrypt/32/4096      40813 ns        40669 ns        17240 bytes_per_second=96.8003M/s
-isap_bench::isap_a_128a_aead_decrypt/32/4096      41865 ns        41548 ns        17261 bytes_per_second=94.7533M/s
-isap_bench::isap_a_128_aead_encrypt/32/64         14375 ns        13820 ns        50083 bytes_per_second=6.62442M/s
-isap_bench::isap_a_128_aead_decrypt/32/64         13372 ns        13342 ns        50934 bytes_per_second=6.86195M/s
-isap_bench::isap_a_128_aead_encrypt/32/128        14727 ns        14622 ns        49257 bytes_per_second=10.4353M/s
-isap_bench::isap_a_128_aead_decrypt/32/128        14974 ns        14852 ns        48791 bytes_per_second=10.2742M/s
-isap_bench::isap_a_128_aead_encrypt/32/256        16046 ns        15938 ns        43132 bytes_per_second=17.2327M/s
-isap_bench::isap_a_128_aead_decrypt/32/256        15629 ns        15541 ns        44924 bytes_per_second=17.6736M/s
-isap_bench::isap_a_128_aead_encrypt/32/512        19686 ns        19394 ns        36001 bytes_per_second=26.7498M/s
-isap_bench::isap_a_128_aead_decrypt/32/512        19633 ns        19347 ns        35838 bytes_per_second=26.816M/s
-isap_bench::isap_a_128_aead_encrypt/32/1024       24448 ns        24431 ns        27735 bytes_per_second=41.2209M/s
-isap_bench::isap_a_128_aead_decrypt/32/1024       24467 ns        24446 ns        28455 bytes_per_second=41.1961M/s
-isap_bench::isap_a_128_aead_encrypt/32/2048       36470 ns        36439 ns        19182 bytes_per_second=54.4369M/s
-isap_bench::isap_a_128_aead_decrypt/32/2048       36774 ns        36744 ns        19131 bytes_per_second=53.9854M/s
-isap_bench::isap_a_128_aead_encrypt/32/4096       60544 ns        60514 ns        11127 bytes_per_second=65.056M/s
-isap_bench::isap_a_128_aead_decrypt/32/4096       61678 ns        61528 ns        10933 bytes_per_second=63.9838M/s
+isap_bench::ascon_permutation<1>                   4.63 ns         4.63 ns    137327605 bytes_per_second=8.05435G/s
+isap_bench::ascon_permutation<6>                   25.7 ns         25.6 ns     28171962 bytes_per_second=1.45751G/s
+isap_bench::ascon_permutation<12>                  49.4 ns         48.7 ns     14675391 bytes_per_second=782.949M/s
+isap_bench::keccak_permutation<1>                  39.9 ns         39.7 ns     17469036 bytes_per_second=1.17434G/s
+isap_bench::keccak_permutation<8>                   333 ns          330 ns      2252658 bytes_per_second=144.371M/s
+isap_bench::keccak_permutation<12>                  478 ns          476 ns      1389137 bytes_per_second=100.227M/s
+isap_bench::keccak_permutation<16>                  609 ns          609 ns      1122029 bytes_per_second=78.3257M/s
+isap_bench::keccak_permutation<20>                  774 ns          773 ns       894980 bytes_per_second=61.7132M/s
+isap_bench::isap_a_128a_aead_encrypt/32/64         2295 ns         2293 ns       304007 bytes_per_second=39.9247M/s
+isap_bench::isap_a_128a_aead_decrypt/32/64         2301 ns         2298 ns       304764 bytes_per_second=39.8406M/s
+isap_bench::isap_a_128a_aead_encrypt/32/128        2896 ns         2891 ns       238422 bytes_per_second=52.7876M/s
+isap_bench::isap_a_128a_aead_decrypt/32/128        2884 ns         2883 ns       241968 bytes_per_second=52.9317M/s
+isap_bench::isap_a_128a_aead_encrypt/32/256        4055 ns         4053 ns       173251 bytes_per_second=67.766M/s
+isap_bench::isap_a_128a_aead_decrypt/32/256        4049 ns         4046 ns       171816 bytes_per_second=67.8795M/s
+isap_bench::isap_a_128a_aead_encrypt/32/512        6384 ns         6381 ns       106678 bytes_per_second=81.3034M/s
+isap_bench::isap_a_128a_aead_decrypt/32/512        6382 ns         6378 ns       107638 bytes_per_second=81.3393M/s
+isap_bench::isap_a_128a_aead_encrypt/32/1024      10971 ns        10967 ns        62245 bytes_per_second=91.8278M/s
+isap_bench::isap_a_128a_aead_decrypt/32/1024      11007 ns        11001 ns        62401 bytes_per_second=91.5447M/s
+isap_bench::isap_a_128a_aead_encrypt/32/2048      20567 ns        20551 ns        34301 bytes_per_second=96.5237M/s
+isap_bench::isap_a_128a_aead_decrypt/32/2048      20387 ns        20366 ns        34122 bytes_per_second=97.4005M/s
+isap_bench::isap_a_128a_aead_encrypt/32/4096      39082 ns        39059 ns        17766 bytes_per_second=100.789M/s
+isap_bench::isap_a_128a_aead_decrypt/32/4096      39160 ns        39124 ns        17897 bytes_per_second=100.622M/s
+isap_bench::isap_a_128_aead_encrypt/32/64         12920 ns        12908 ns        52971 bytes_per_second=7.09257M/s
+isap_bench::isap_a_128_aead_decrypt/32/64         12913 ns        12902 ns        53367 bytes_per_second=7.09592M/s
+isap_bench::isap_a_128_aead_encrypt/32/128        13677 ns        13671 ns        50618 bytes_per_second=11.1617M/s
+isap_bench::isap_a_128_aead_decrypt/32/128        13690 ns        13681 ns        50957 bytes_per_second=11.1533M/s
+isap_bench::isap_a_128_aead_encrypt/32/256        15151 ns        15143 ns        45569 bytes_per_second=18.1381M/s
+isap_bench::isap_a_128_aead_decrypt/32/256        15106 ns        15099 ns        45336 bytes_per_second=18.1902M/s
+isap_bench::isap_a_128_aead_encrypt/32/512        18155 ns        18142 ns        37710 bytes_per_second=28.5968M/s
+isap_bench::isap_a_128_aead_decrypt/32/512        18195 ns        18182 ns        37259 bytes_per_second=28.5342M/s
+isap_bench::isap_a_128_aead_encrypt/32/1024       24287 ns        24267 ns        28809 bytes_per_second=41.5002M/s
+isap_bench::isap_a_128_aead_decrypt/32/1024       24389 ns        24360 ns        28726 bytes_per_second=41.3421M/s
+isap_bench::isap_a_128_aead_encrypt/32/2048       36168 ns        36147 ns        19143 bytes_per_second=54.8773M/s
+isap_bench::isap_a_128_aead_decrypt/32/2048       36280 ns        36258 ns        19019 bytes_per_second=54.7087M/s
+isap_bench::isap_a_128_aead_encrypt/32/4096       60532 ns        60487 ns        11274 bytes_per_second=65.0844M/s
+isap_bench::isap_a_128_aead_decrypt/32/4096       61136 ns        61086 ns        11281 bytes_per_second=64.446M/s
+isap_bench::isap_k_128a_aead_encrypt/32/64        17151 ns        17141 ns        40655 bytes_per_second=5.34109M/s
+isap_bench::isap_k_128a_aead_decrypt/32/64        17067 ns        17055 ns        39939 bytes_per_second=5.36809M/s
+isap_bench::isap_k_128a_aead_encrypt/32/128       20768 ns        20752 ns        33295 bytes_per_second=7.35286M/s
+isap_bench::isap_k_128a_aead_decrypt/32/128       20724 ns        20711 ns        33455 bytes_per_second=7.36742M/s
+isap_bench::isap_k_128a_aead_encrypt/32/256       27136 ns        27126 ns        25445 bytes_per_second=10.1254M/s
+isap_bench::isap_k_128a_aead_decrypt/32/256       27342 ns        27327 ns        25362 bytes_per_second=10.0508M/s
+isap_bench::isap_k_128a_aead_encrypt/32/512       40599 ns        40562 ns        17303 bytes_per_second=12.7902M/s
+isap_bench::isap_k_128a_aead_decrypt/32/512       40235 ns        40196 ns        17323 bytes_per_second=12.9068M/s
+isap_bench::isap_k_128a_aead_encrypt/32/1024      65903 ns        65881 ns        10221 bytes_per_second=15.2864M/s
+isap_bench::isap_k_128a_aead_decrypt/32/1024      66027 ns        65993 ns        10128 bytes_per_second=15.2605M/s
+isap_bench::isap_k_128a_aead_encrypt/32/2048     118771 ns       118685 ns         5810 bytes_per_second=16.7136M/s
+isap_bench::isap_k_128a_aead_decrypt/32/2048     119455 ns       119371 ns         5839 bytes_per_second=16.6174M/s
+isap_bench::isap_k_128a_aead_encrypt/32/4096     224535 ns       224396 ns         3115 bytes_per_second=17.5438M/s
+isap_bench::isap_k_128a_aead_decrypt/32/4096     223915 ns       223773 ns         3101 bytes_per_second=17.5927M/s
+isap_bench::isap_k_128_aead_encrypt/32/64        125791 ns       125707 ns         5489 bytes_per_second=745.779k/s
+isap_bench::isap_k_128_aead_decrypt/32/64        125646 ns       125603 ns         5471 bytes_per_second=746.4k/s
+isap_bench::isap_k_128_aead_encrypt/32/128       130883 ns       130792 ns         5210 bytes_per_second=1.16664M/s
+isap_bench::isap_k_128_aead_decrypt/32/128       131299 ns       131189 ns         5263 bytes_per_second=1.16311M/s
+isap_bench::isap_k_128_aead_encrypt/32/256       139498 ns       139453 ns         4917 bytes_per_second=1.96953M/s
+isap_bench::isap_k_128_aead_decrypt/32/256       139817 ns       139755 ns         4960 bytes_per_second=1.96529M/s
+isap_bench::isap_k_128_aead_encrypt/32/512       156481 ns       156402 ns         4433 bytes_per_second=3.31709M/s
+isap_bench::isap_k_128_aead_decrypt/32/512       157513 ns       157370 ns         4413 bytes_per_second=3.29669M/s
+isap_bench::isap_k_128_aead_encrypt/32/1024      202944 ns       199982 ns         3626 bytes_per_second=5.03587M/s
+isap_bench::isap_k_128_aead_decrypt/32/1024      190851 ns       190740 ns         3590 bytes_per_second=5.27987M/s
+isap_bench::isap_k_128_aead_encrypt/32/2048      260141 ns       260021 ns         2659 bytes_per_second=7.62878M/s
+isap_bench::isap_k_128_aead_decrypt/32/2048      260383 ns       260305 ns         2661 bytes_per_second=7.62045M/s
+isap_bench::isap_k_128_aead_encrypt/32/4096      402613 ns       402320 ns         1735 bytes_per_second=9.78515M/s
+isap_bench::isap_k_128_aead_decrypt/32/4096      405033 ns       404202 ns         1745 bytes_per_second=9.73961M/s
 ```
 
 ## Usage

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,7 +1,21 @@
+#include "bench_ascon.hpp"
 #include "bench_isap_a_128.hpp"
 #include "bench_isap_a_128a.hpp"
 #include "bench_isap_k_128.hpp"
 #include "bench_isap_k_128a.hpp"
+#include "bench_keccak.hpp"
+
+// registering Ascon permutation for benchmark
+BENCHMARK(isap_bench::ascon_permutation<1>);
+BENCHMARK(isap_bench::ascon_permutation<6>);
+BENCHMARK(isap_bench::ascon_permutation<12>);
+
+// registering Keccak-p[400] permutation for benchmark
+BENCHMARK(isap_bench::keccak_permutation<1>);
+BENCHMARK(isap_bench::keccak_permutation<8>);
+BENCHMARK(isap_bench::keccak_permutation<12>);
+BENCHMARK(isap_bench::keccak_permutation<16>);
+BENCHMARK(isap_bench::keccak_permutation<20>);
 
 // registering ISAP-A-128A encrypt/ decrypt routines for benchmark
 BENCHMARK(isap_bench::isap_a_128a_aead_encrypt)->Args({ 32, 64 });

--- a/example/isap_a_128.cpp
+++ b/example/isap_a_128.cpp
@@ -23,10 +23,10 @@ main()
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * mlen));
 
   // generate random bytes
-  random_data(key, kntlen);
-  random_data(nonce, kntlen);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, kntlen);
+  random_data<uint8_t>(nonce, kntlen);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   // clear memory allocations
   std::memset(tag, 0, kntlen);

--- a/example/isap_a_128a.cpp
+++ b/example/isap_a_128a.cpp
@@ -23,10 +23,10 @@ main()
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * mlen));
 
   // generate random bytes
-  random_data(key, kntlen);
-  random_data(nonce, kntlen);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, kntlen);
+  random_data<uint8_t>(nonce, kntlen);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   // clear memory allocations
   std::memset(tag, 0, kntlen);

--- a/example/isap_k_128.cpp
+++ b/example/isap_k_128.cpp
@@ -23,10 +23,10 @@ main()
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * mlen));
 
   // generate random bytes
-  random_data(key, kntlen);
-  random_data(nonce, kntlen);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, kntlen);
+  random_data<uint8_t>(nonce, kntlen);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   // clear memory allocations
   std::memset(tag, 0, kntlen);

--- a/example/isap_k_128a.cpp
+++ b/example/isap_k_128a.cpp
@@ -23,10 +23,10 @@ main()
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(sizeof(uint8_t) * mlen));
 
   // generate random bytes
-  random_data(key, kntlen);
-  random_data(nonce, kntlen);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, kntlen);
+  random_data<uint8_t>(nonce, kntlen);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   // clear memory allocations
   std::memset(tag, 0, kntlen);

--- a/include/bench_ascon.hpp
+++ b/include/bench_ascon.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "ascon.hpp"
+#include <benchmark/benchmark.h>
+
+// Benchmark ISAP Authenticated Encryption with Associated Data
+namespace isap_bench {
+
+// Benchmarks Ascon permutation on CPU based systems, for specified # -of rounds
+template<const size_t ROUNDS>
+static void
+ascon_permutation(benchmark::State& state)
+{
+  uint64_t pstate[5];
+  random_data<uint64_t>(pstate, 5);
+
+  for (auto _ : state) {
+    ascon::permute<ROUNDS>(pstate);
+
+    benchmark::DoNotOptimize(pstate);
+    benchmark::ClobberMemory();
+  }
+
+  constexpr size_t per_itr = sizeof(pstate);
+  state.SetBytesProcessed(static_cast<int64_t>(per_itr * state.iterations()));
+}
+
+}

--- a/include/bench_isap_a_128.hpp
+++ b/include/bench_isap_a_128.hpp
@@ -22,10 +22,10 @@ isap_a_128_aead_encrypt(benchmark::State& state)
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
 
-  random_data(key, 16);
-  random_data(nonce, 16);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, 16);
+  random_data<uint8_t>(nonce, 16);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   std::memset(tag, 0, 16);
   std::memset(enc, 0, mlen);
@@ -80,10 +80,10 @@ isap_a_128_aead_decrypt(benchmark::State& state)
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
 
-  random_data(key, 16);
-  random_data(nonce, 16);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, 16);
+  random_data<uint8_t>(nonce, 16);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   std::memset(tag, 0, 16);
   std::memset(enc, 0, mlen);

--- a/include/bench_isap_a_128a.hpp
+++ b/include/bench_isap_a_128a.hpp
@@ -22,10 +22,10 @@ isap_a_128a_aead_encrypt(benchmark::State& state)
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
 
-  random_data(key, 16);
-  random_data(nonce, 16);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, 16);
+  random_data<uint8_t>(nonce, 16);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   std::memset(tag, 0, 16);
   std::memset(enc, 0, mlen);
@@ -80,10 +80,10 @@ isap_a_128a_aead_decrypt(benchmark::State& state)
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
 
-  random_data(key, 16);
-  random_data(nonce, 16);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, 16);
+  random_data<uint8_t>(nonce, 16);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   std::memset(tag, 0, 16);
   std::memset(enc, 0, mlen);

--- a/include/bench_isap_k_128.hpp
+++ b/include/bench_isap_k_128.hpp
@@ -22,10 +22,10 @@ isap_k_128_aead_encrypt(benchmark::State& state)
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
 
-  random_data(key, 16);
-  random_data(nonce, 16);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, 16);
+  random_data<uint8_t>(nonce, 16);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   std::memset(tag, 0, 16);
   std::memset(enc, 0, mlen);
@@ -80,10 +80,10 @@ isap_k_128_aead_decrypt(benchmark::State& state)
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
 
-  random_data(key, 16);
-  random_data(nonce, 16);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, 16);
+  random_data<uint8_t>(nonce, 16);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   std::memset(tag, 0, 16);
   std::memset(enc, 0, mlen);

--- a/include/bench_isap_k_128a.hpp
+++ b/include/bench_isap_k_128a.hpp
@@ -22,10 +22,10 @@ isap_k_128a_aead_encrypt(benchmark::State& state)
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
 
-  random_data(key, 16);
-  random_data(nonce, 16);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, 16);
+  random_data<uint8_t>(nonce, 16);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   std::memset(tag, 0, 16);
   std::memset(enc, 0, mlen);
@@ -80,10 +80,10 @@ isap_k_128a_aead_decrypt(benchmark::State& state)
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(mlen));
 
-  random_data(key, 16);
-  random_data(nonce, 16);
-  random_data(data, dlen);
-  random_data(txt, mlen);
+  random_data<uint8_t>(key, 16);
+  random_data<uint8_t>(nonce, 16);
+  random_data<uint8_t>(data, dlen);
+  random_data<uint8_t>(txt, mlen);
 
   std::memset(tag, 0, 16);
   std::memset(enc, 0, mlen);

--- a/include/bench_keccak.hpp
+++ b/include/bench_keccak.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "keccak.hpp"
+#include <benchmark/benchmark.h>
+
+// Benchmark ISAP Authenticated Encryption with Associated Data
+namespace isap_bench {
+
+// Benchmarks Keccak-p[400] permutation on CPU based systems, for specified #
+// -of rounds
+template<const size_t ROUNDS>
+static void
+keccak_permutation(benchmark::State& state)
+{
+  uint16_t pstate[25];
+  random_data<uint16_t>(pstate, 25);
+
+  for (auto _ : state) {
+    keccak::permute<ROUNDS>(pstate);
+
+    benchmark::DoNotOptimize(pstate);
+    benchmark::ClobberMemory();
+  }
+
+  constexpr size_t per_itr = sizeof(pstate);
+  state.SetBytesProcessed(static_cast<int64_t>(per_itr * state.iterations()));
+}
+
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <random>
 #include <sstream>
+#include <type_traits>
 
 // Compile-time check to ensure # -of rounds Ascon-p/ Keccak-p[400] permutation
 // to be applied, is lesser than or equal to `n`
@@ -28,13 +29,14 @@ to_hex(const uint8_t* const bytes, const size_t len)
   return ss.str();
 }
 
-// Generates N -many random bytes | N >= 0
+// Generates N -many random elements of type T | N >= 0
+template<typename T>
 inline static void
-random_data(uint8_t* const data, const size_t dlen)
+random_data(T* const data, const size_t dlen) requires(std::is_integral_v<T>)
 {
   std::random_device rd;
   std::mt19937_64 gen(rd());
-  std::uniform_int_distribution<uint8_t> dis;
+  std::uniform_int_distribution<T> dis;
 
   for (size_t i = 0; i < dlen; i++) {
     data[i] = dis(gen);


### PR DESCRIPTION
Benchmark multiple rounds of both Ascon & Keccak-p[400] permutations, which are used as underlying building block of ISAP AEAD schemes. 